### PR TITLE
Add InternCompass as a way to find companies to apply to

### DIFF
--- a/docs/1-Applying/finding_companies_to_apply_to.md
+++ b/docs/1-Applying/finding_companies_to_apply_to.md
@@ -4,6 +4,7 @@
 
 You can often find lists online of companies hiring for summer internships. Internships at other times of the year can be trickier, but you can always email companies that do summer internships and ask if they'll hire at other times of the year.
 
+- [InternCompass](https://interncompass.io) (internship reviews and links to application pages)
 - [Intern Supply](http://www.intern.supply/) (links you directly to the application page of a lot of companies)
 - [Research in the US](https://www.nsf.gov/crssprgm/reu/list_result.jsp?unitid=5049)
 - [Indeed.com](https://www.indeed.com/) (job board)


### PR DESCRIPTION
A bit of self-promotion here, but InternCompass is largely meant for helping students find and prepare for internships; it has direct links to application pages, reviews, location filtering, and more coming soon, so I think it would be a good fit.